### PR TITLE
Fixed missing crypto_LIBRARY

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,13 +86,22 @@ jobs:
         run: |
           .github/workflows/linux-ci-helper.sh ${{ matrix.container }}
 
+      # [NOTE]
+      # In Rocky Linux and OpenSUSE, a "missing crypto_LIBRARY" error occurs
+      # because the static crypto library does not exist.
+      # Therefore, set USE_OPENSSL=OFF and use AWS-LC.
+      #
       - name: Build aws-sdk-cpp
         run: |
           mkdir -p /tmp/aws-sdk/sdk_build
           cd /tmp/aws-sdk
           git clone --recurse-submodules https://github.com/aws/aws-sdk-cpp
           cd sdk_build
-          cmake ../aws-sdk-cpp -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=/home/ggtakec/work/aws-sdk-cpp -DBUILD_ONLY="core;identity-management" -DAUTORUN_UNIT_TESTS=OFF 
+          if [ "${{ matrix.container }}" = "rockylinux:8" ] || [ "${{ matrix.container }}" = "opensuse/leap:15" ]; then
+            cmake ../aws-sdk-cpp -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=/home/ggtakec/work/aws-sdk-cpp -DBUILD_ONLY="core;identity-management" -DAUTORUN_UNIT_TESTS=OFF -DUSE_OPENSSL=OFF
+          else
+            cmake ../aws-sdk-cpp -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=/home/ggtakec/work/aws-sdk-cpp -DBUILD_ONLY="core;identity-management" -DAUTORUN_UNIT_TESTS=OFF 
+          fi
           make
           make install
 

--- a/.github/workflows/linux-ci-helper.sh
+++ b/.github/workflows/linux-ci-helper.sh
@@ -98,7 +98,7 @@ elif [ "${CONTAINER_FULLNAME}" = "fedora:35" ]; then
 	PACKAGE_MANAGER_BIN="dnf"
 	PACKAGE_UPDATE_OPTIONS="update -y -qq"
 
-	INSTALL_PACKAGES="git gcc-c++ cmake libcurl-devel openssl-devel uuid-devel zlib-devel pulseaudio-libs-devel"
+	INSTALL_PACKAGES="git gcc-c++ cmake libcurl-devel openssl-devel openssl-static uuid-devel zlib-devel pulseaudio-libs-devel"
 	INSTALL_REPO_OPTIONS=""
 
 elif [ "${CONTAINER_FULLNAME}" = "opensuse/leap:15" ]; then


### PR DESCRIPTION
## Relevant Issue (if applicable)
n/a

## Details
`Rocky Linux:8`, `fedora:35` and `opensuse/leap:15` now give the following error:
```
CMake Error at /usr/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:230 (message):
  Could NOT find crypto (missing: crypto_LIBRARY)
Call Stack (most recent call first):
  /usr/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:594 (_FPHSA_FAILURE_MESSAGE)
  /usr/local/lib64/s2n/cmake/modules/Findcrypto.cmake:67 (find_package_handle_standard_args)
  /usr/share/cmake/Modules/CMakeFindDependencyMacro.cmake:[47](https://github.com/ggtakec/s3fs-fuse-awscred-lib/runs/6112977881?check_suite_focus=true#step:7:47) (find_package)
  /usr/local/lib64/s2n/cmake/s2n-config.cmake:9 (find_dependency)
  /usr/share/cmake/Modules/CMakeFindDependencyMacro.cmake:47 (find_package)
  /usr/local/lib64/aws-c-io/cmake/aws-c-io-config.cmake:4 (find_dependency)
  /usr/share/cmake/Modules/CMakeFindDependencyMacro.cmake:47 (find_package)
  /usr/local/lib64/aws-c-http/cmake/aws-c-http-config.cmake:3 (find_dependency)
  /usr/share/cmake/Modules/CMakeFindDependencyMacro.cmake:47 (find_package)
  /usr/local/lib64/aws-crt-cpp/cmake/aws-crt-cpp-config.cmake:3 (find_dependency)
  /usr/share/cmake/Modules/CMakeFindDependencyMacro.cmake:47 (find_package)
  /usr/local/lib64/cmake/aws-cpp-sdk-core/aws-cpp-sdk-core-config.cmake:13 (find_dependency)
  /usr/local/lib64/cmake/AWSSDK/AWSSDKConfig.cmake:307 (find_package)
  CMakeLists.txt:58 (find_package)
```

In order to avoid this, the following measures have been taken for each.
- `fedora:35` installs the `openssl-static` package.
- In `Rocky Linux:8`, `opensuse/leap:15`, added the `USE_OPENSSL=OFF` flag and executed the build to use `AWS-LC`.