### PR TITLE
Added diffutils package for CI test on fedora35

### DIFF
--- a/.github/workflows/linux-ci-helper.sh
+++ b/.github/workflows/linux-ci-helper.sh
@@ -98,7 +98,7 @@ elif [ "${CONTAINER_FULLNAME}" = "fedora:35" ]; then
 	PACKAGE_MANAGER_BIN="dnf"
 	PACKAGE_UPDATE_OPTIONS="update -y -qq"
 
-	INSTALL_PACKAGES="git gcc-c++ cmake libcurl-devel openssl-devel openssl-static uuid-devel zlib-devel pulseaudio-libs-devel"
+	INSTALL_PACKAGES="git gcc-c++ cmake libcurl-devel openssl-devel openssl-static uuid-devel zlib-devel pulseaudio-libs-devel diffutils"
 	INSTALL_REPO_OPTIONS=""
 
 elif [ "${CONTAINER_FULLNAME}" = "opensuse/leap:15" ]; then


### PR DESCRIPTION
## Relevant Issue (if applicable)
n/a

## Details
In the test on `fedora 35` of Github Actions, there was no diff command and an error occurred.
For `fedora 35`, changed to install the `diffutils` package.