### PR TITLE
Updated linux-ci-helper.sh for installing diffutils on rocky linux

### DIFF
--- a/.github/workflows/linux-ci-helper.sh
+++ b/.github/workflows/linux-ci-helper.sh
@@ -84,7 +84,7 @@ elif [ "${CONTAINER_FULLNAME}" = "rockylinux:8" ]; then
 	PACKAGE_MANAGER_BIN="dnf"
 	PACKAGE_UPDATE_OPTIONS="update -y -qq"
 
-	INSTALL_PACKAGES="git gcc-c++ cmake libcurl-devel openssl-devel uuid-devel zlib-devel pulseaudio-libs-devel"
+	INSTALL_PACKAGES="git gcc-c++ cmake libcurl-devel openssl-devel uuid-devel zlib-devel pulseaudio-libs-devel diffutils"
 	INSTALL_REPO_OPTIONS="--enablerepo=powertools"
 
 elif [ "${CONTAINER_FULLNAME}" = "centos:centos7" ]; then


### PR DESCRIPTION
Github Actions(test) for Rocky Linux required the installation of the diffutils package, so I added it.