### PR TITLE
Add docker build tooling to help build a local set of working libraries

### DIFF
--- a/contrib/Makefile
+++ b/contrib/Makefile
@@ -1,0 +1,8 @@
+BUILD_DIR := $(dir $(abspath $(firstword $(MAKEFILE_LIST))))
+DOCKER := $(shell test -x /usr/bin/podman && echo podman || echo docker)
+
+build-ubuntu: 22.04
+
+18.04 20.04 22.04 24.04:
+	$(DOCKER) build -f $(BUILD_DIR)/build-ubuntu.Dockerfile --build-arg RELEASE=$@ -t build-awscred-lib .
+	$(DOCKER) run -ti --rm -v ./:/build build-awscred-lib

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -1,0 +1,28 @@
+# Helpers for building s3fs-fuse-awscred-lib
+
+The tools in this directory can be used to build the library locally, so it can either
+be installed manually or just used from the current directory.
+
+## Requirements:
+
+ - Linux
+ - Docker, Podman or an alternative container runtime
+ - GNU Make (optional, read `Makefile` for alternative instructions)
+
+## Usage
+
+The provided `Makefile` currently supports building for the currently supported
+Ubuntu LTS versions.
+
+To build all the required binaries, including the test tool, and copy them into the
+current directory, run:
+
+`make -f contrib/Makefile [UBUNTU_VERSION]`
+
+where `UBUNTU_VERSION` is optional and can be an LTS version number such as `20.04`.
+If not specified, `22.04` is used (which is the current latest LTS release).
+
+After the build is complete, the resulting `.so` files can be manually copied to
+someplace in the dynamic linker path (for example `/usr/local/lib`) or can be
+loaded directly by setting the environment variable `LD_LIBRARY_PATH` for the
+`s3fs` command, e.g. `LD_LIBRARY_PATH=. s3fs …`

--- a/contrib/build-ubuntu.Dockerfile
+++ b/contrib/build-ubuntu.Dockerfile
@@ -1,0 +1,23 @@
+ARG RELEASE=20.04
+FROM ubuntu:$RELEASE
+ENV DEBIAN_FRONTEND=noninteractive
+WORKDIR /src
+RUN apt-get update && apt-get install -qy devscripts \
+	libcurl4-openssl-dev libssl-dev uuid-dev zlib1g-dev libpulse-dev \
+	git cmake
+RUN git clone --recurse-submodules https://github.com/aws/aws-sdk-cpp
+RUN mkdir sdk_build && cd sdk_build && \
+	cmake ../aws-sdk-cpp -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=${PWD} \
+	-DBUILD_ONLY="core;identity-management" -DAUTORUN_UNIT_TESTS=OFF && make && make install
+ADD ./ /src/s3fs-fuse-awscred-lib
+RUN cd s3fs-fuse-awscred-lib && \
+	cmake -S . -B build && \
+	cmake --build build
+VOLUME /build
+CMD mkdir -p /build && cp /src/s3fs-fuse-awscred-lib/build/libs3fsawscred.so \
+	/src/s3fs-fuse-awscred-lib/build/s3fsawscred_test \
+	/usr/local/lib/libaws-cpp-sdk-identity-management.so \
+	/usr/local/lib/libaws-cpp-sdk-core.so \
+	/usr/local/lib/libaws-cpp-sdk-cognito-identity.so \
+	/usr/local/lib/libaws-cpp-sdk-sts.so \
+	/build


### PR DESCRIPTION
I found it useful to have a reproduceable build setup that works without needing to install development libraries (and especially the AWS C++ SDK, for which there isn't a ready package), and the GitHub Workflows CI setup didn't work for me, so I've built this.

If you think this is interesting but would rather it be changed in someway - please let me know and I will try my best to accommodate. If you do not think this would be useful in the main `s3fs-fuse-awscred-lib` - that's also OK :shrug: .