### PR TITLE
Improved to add option for Session Token Period Second

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,10 @@ _These options are the same as the log level defined in `aws-sdk-cpp`(Aws::Utils
 - SSOProfile(SSOProf)  
 Specify the SSO profile name. _(mainly the name written in sso-session in `.aws/config`.)_  
 _This DSO cannot handle that authentication callback when it comes to SSO, so it is a temporary token acquisition._
+- TokenPeriodSecond(PeriodSec)  
+Specify the validity period of the Session Token in seconds.  
+_If this option is specified, the Session Token will be considered valid for this validity period(in seconds), starting from the first time this Token is read._  
+_User cannot set an expiration date for Credentials(`.aws/<file>` or environment variables), so if this value is not set, the expiration date will indicate a long time in the future._  
 
 If you want to specify multiple options above, please specify them using a comma(`,`) as a delimiter.
 


### PR DESCRIPTION
### Relevant Issue (if applicable)
n/a

### Details
This library does not support session token generation(login processing) for STS/SSO, etc., so normally it is necessary to write the session token in Credentials(`.aws/<file>` or environment variables).
Therefore, to update the Session Token, you will need to use an external program to update the Credential.

However, it is not possible to specify an expiration date for Session Token, so the expiration date is always determined to be in the future.
Therefore, there is a problem that s3fs continues to use an expired Session Token.
(Even if s3fs determines that the Session Token has expired, there is no process to update it, so you need to notice this phenomenon and update it using another program.)

Added an option to specify the validity period(in seconds) of the Session Token in this PR.(This probably doesn't help much.)
Please see the revised README.md for details.